### PR TITLE
Made soundboard slash command ephemeral

### DIFF
--- a/bot/src/discord/commands/SoundboardCommand.ts
+++ b/bot/src/discord/commands/SoundboardCommand.ts
@@ -70,6 +70,6 @@ export class SoundboardCommand extends DiscordCommand {
       })
     });
     const fullComponents = convertButtonsIntoButtonGrid(buttons);
-    return discordCommandResponder.sendBackMessage("Here's the menu for that sound.", true, fullComponents);
+    return discordCommandResponder.sendBackMessage("Here's the menu for that sound.", false, fullComponents);
   }
 }


### PR DESCRIPTION
## What?
Converted the `/soundboard <argument>` command to only be shown to the account invoking by default.
## Why?
Popular server request to hide soundboard requests. Commonly cited reasons are general channel clutter and large walls of text.
## How?
Under:
https://github.com/agnorat1887/airhornbot/blob/a7621dac09676f4cebf7d830425236a144138bdc/bot/src/discord/DiscordInteraction.ts#L119-L128
The [showForAll: boolean] is used by the Discord API to check whether a message should display as ephemeral or not.

We change the airhornbot response from `showForAll = true` to `showForAll = false`
## Testing?
No individual testing done. This edit follows a similar structure as displayed here:
https://github.com/agnorat1887/airhornbot/blob/a7621dac09676f4cebf7d830425236a144138bdc/bot/src/discord/commands/AirhornMetaCommand.ts#L22
This command is currently ephemeral. We use the same structure (invoking the function with `showForAll = false`) in this change.

## Anything Else?
We should consider allowing a way to manually create a publicly viewable soundboard request. This could take the form of an extra argument or a new endpoint.